### PR TITLE
:truck: Rename sensor sdk artifact

### DIFF
--- a/libs/privsdk/build.gradle.kts
+++ b/libs/privsdk/build.gradle.kts
@@ -1,2 +1,2 @@
 configurations.maybeCreate("default")
-artifacts.add("default", file("priv-health-tracking-v1.2.0.aar"))
+artifacts.add("default", file("samsung-health-sensor-api-v1.3.0.aar"))


### PR DESCRIPTION
https://developer.samsung.com/health/sensor/process.html?download=%2FSHealth%2Ffile%2Ffc765a23-c44a-4826-9194-3e89e7622bb3

Download SensorSDK zip file from the link above.
Unzip the file, you may find `1.3.0/libs/samsung-health-sensor-api-v1.3.0.aar`.

Place that aar file in `libs/privsdk/samsung-health-sensor-api-v1.3.0.aar` of this repository.

Then the wearable apps build will success.

Please make sure enabling `Health Platform Developer Mode` to make sensors work.